### PR TITLE
Fewer pip arguments, only python and pip in 'host' section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupytext" %}
-{% set version = "0.8.3" %}
+{% set version = "0.8.4" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 05203c7efc0c7de6947a401538045a42deddbe0b01ed304905f1c9e293d0e742
+  sha256: 0778a58bc45b0f96bd2559b51c3e451e8e52ef041e7d9c672d8b5595f662d0ce
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - jupytext = jupytext.cli:jupytext
   noarch: python
-  script: "{{ PYTHON }} -m pip install . -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,16 @@ source:
   sha256: 0778a58bc45b0f96bd2559b51c3e451e8e52ef041e7d9c672d8b5595f662d0ce
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - jupytext = jupytext.cli:jupytext
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
 
 requirements:
   host:
-    - nbformat >=4.0.0
     - pip
     - python
-    - pyyaml
   run:
     - mock
     - nbformat >=4.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - jupytext = jupytext.cli:jupytext
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
+  script: "{{ PYTHON }} -m pip install . -vvv"
 
 requirements:
   host:
@@ -23,7 +23,6 @@ requirements:
   run:
     - mock
     - nbformat >=4.0.0
-    - python
     - pyyaml
     - testfixtures
 
@@ -35,10 +34,19 @@ test:
 
 about:
   home: https://github.com/mwouts/jupytext
+  doc_url: https://github.com/mwouts/jupytext/blob/master/README.md
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: Jupyter notebooks as Markdown documents, Julia, Python or R scripts
+  description: |
+    Represent Jupyter notebooks as Markdown documents or Julia, Python or R scripts. Convert any
+    script or Markdown document to a Jupyter notebook. Round trip conversion is robust and well tested.
+
+    Use these simpler representations to do version control and collaborate on Jupyter notebooks.
+    And refactor your notebooks encoded as scripts in your favorite IDE.
+
+    Jupytext is available directly in Jupyter Notebook and JupyterLab, and also on the command line.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

@conda-forge-admin, please rerender