### PR TITLE
The base branch of Jupytext is `main`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
 
 about:
   home: https://github.com/mwouts/jupytext
-  doc_url: https://github.com/mwouts/jupytext/blob/master/README.md
+  doc_url: https://github.com/mwouts/jupytext/blob/main/README.md
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
This is a tentative fix for #106.

At the moment I have identified a single reference to the old master branch and it was through the README, so this PR might require more work.